### PR TITLE
fix: remove hardcoded provider version in module

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,13 @@ module "tfmodule-azure-actiongroup" {
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| azurerm | =2.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| azurerm | =2.0.0 |
+| azurerm | n/a |
 
 ## Inputs
 

--- a/example/email/main.tf
+++ b/example/email/main.tf
@@ -1,3 +1,9 @@
+provider "azurerm" {
+  # whilst the `version` attribute is optional, we recommend pinning to a given version of the Provider
+  version = "=2.17.0"
+  features {}
+}
+
 module "actionGroup" {
   source = "../../"
 

--- a/example/emailAndWebHook/main.tf
+++ b/example/emailAndWebHook/main.tf
@@ -1,3 +1,9 @@
+provider "azurerm" {
+  # whilst the `version` attribute is optional, we recommend pinning to a given version of the Provider
+  version = "=2.17.0"
+  features {}
+}
+
 module "actionGroup" {
   source = "../../"
 

--- a/example/sms/main.tf
+++ b/example/sms/main.tf
@@ -1,3 +1,9 @@
+provider "azurerm" {
+  # whilst the `version` attribute is optional, we recommend pinning to a given version of the Provider
+  version = "=2.17.0"
+  features {}
+}
+
 module "actionGroup" {
   source = "../../"
 

--- a/example/webhook/main.tf
+++ b/example/webhook/main.tf
@@ -1,3 +1,9 @@
+provider "azurerm" {
+  # whilst the `version` attribute is optional, we recommend pinning to a given version of the Provider
+  version = "=2.17.0"
+  features {}
+}
+
 module "actionGroup" {
   source = "../../"
 

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,3 @@
-provider "azurerm" {
-  # whilst the `version` attribute is optional, we recommend pinning to a given version of the Provider
-  version = "=2.0.0"
-  features {}
-}
-
 data "azurerm_resource_group" "rg" {
   name = var.resource-group-name
 }


### PR DESCRIPTION
Learned about moving the provider outside the module.
Provider version is now controlled by the consumer.
See examples.